### PR TITLE
refactor: improve free space splitting algo

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -98,20 +98,17 @@ export function wrapElement<T extends MCItem>(
     const previousItem = getPreviousNonZeroItem(items, isHiddenMap, index);
     const nextItem = getNextNonZeroItem(items, isHiddenMap, index);
 
-    if (!previousItem) {
-      style.paddingTop = getMarginTop(currentItem);
-    } else {
-      style.paddingTop =
-        Math.max(getMarginTop(currentItem), getMarginBottom(previousItem)) / 2;
-    }
-
-    if (!nextItem) {
-      style.paddingBottom = getMarginBottom(currentItem);
-    } else {
-      style.paddingBottom =
-        Math.max(getMarginBottom(currentItem), getMarginTop(nextItem)) / 2;
-    }
+    style.paddingTop = calculateTopMargin(currentItem, previousItem);
+    style.paddingBottom = calculateBottomMargin(currentItem, nextItem);
   }
+
+  console.log(
+    'Item key:',
+    key,
+    'style:',
+    style.paddingTop,
+    style.paddingBottom
+  );
 
   const handleLayout = (event: LayoutChangeEvent) => {
     const isHidden = event.nativeEvent.layout.height === 0;
@@ -132,4 +129,29 @@ export function wrapElement<T extends MCItem>(
       <View onLayout={handleLayout}>{element}</View>
     </View>
   );
+}
+
+function calculateTopMargin(item: MCItem, previousItem: MCItem | null): number {
+  if (!previousItem) {
+    return getMarginTop(item);
+  }
+
+  const selfMargin = getMarginTop(item);
+  const otherMargin = getMarginBottom(previousItem);
+
+  const effectiveMargin = Math.max(selfMargin, otherMargin);
+  const totalMargin = selfMargin + otherMargin;
+  return Math.round((effectiveMargin * selfMargin) / totalMargin);
+}
+
+function calculateBottomMargin(item: MCItem, nextItem?: MCItem | null): number {
+  if (!nextItem) {
+    return getMarginBottom(item);
+  }
+
+  const effectiveMargin = Math.max(
+    getMarginBottom(item),
+    getMarginTop(nextItem)
+  );
+  return effectiveMargin - calculateTopMargin(nextItem, item);
 }


### PR DESCRIPTION
## Summary

Currently the margin space is split 50%/50% between 2 consecutive items. Which can result in item getting more margin the then requested (Item 1 margin request: 20, Item 2 margin request: 0, effective margin at both items: 10)

Modified version takes into account their relative margin requests.